### PR TITLE
Checking for empty username or password during registration

### DIFF
--- a/app/LAMPAPI/RegisterUser.php
+++ b/app/LAMPAPI/RegisterUser.php
@@ -51,6 +51,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
  */
 function register($username, $newPassword, $confirmPassword)
 {
+
+    // Ensuring that username is not empty string
+    if (!is_string($username) || (trim($username) === "")) {
+        $error = "Please provide a valid username";
+        returnWithError($error, 400);
+    }
+
+    // Ensuring that password is not empty string
+    if (!is_string($newPassword) || (trim($newPassword) === "")) {
+        $error = "Please provide a valid password";
+        returnWithError($error, 400);
+    }
+
     // Only allowing for one user per username
     if (userExists($username))
     {


### PR DESCRIPTION
Making sure that the user is not allowed to make a new account with an empty string as the username or password. This will now show up as a message to the user on the frontend. 

Invalid Username Example:
![image](https://github.com/Shi-morrison/Contact-Manager/assets/68172317/ddd58519-42ab-4f2d-9e78-6f61162653b0)
